### PR TITLE
Fix y-axis auto-ranges

### DIFF
--- a/R/fig_cases_vs_load.R
+++ b/R/fig_cases_vs_load.R
@@ -1,4 +1,5 @@
 # Create figures!
+# Font sizes may not render correctly on Mac
 
 library(cowplot)
 library(magick)

--- a/R/fig_copies_by_variant.R
+++ b/R/fig_copies_by_variant.R
@@ -1,4 +1,5 @@
 # Create figures!
+# Font sizes may not render correctly on Mac
 
 library(cowplot)
 library(magick)

--- a/R/fig_variants.R
+++ b/R/fig_variants.R
@@ -3,6 +3,8 @@ library(magick)
 library(ggtext)
 library(showtext)
 library(councilR)
+# Font sizes may not render correctly on Mac
+
 
 font_add("HelveticaNeueLTStd", "HelveticaNeueLTStd-Lt.otf")
 font_add("HelveticaNeueLTStd", "HelveticaNeueLTStd-Lt.otf")

--- a/README.Rmd
+++ b/README.Rmd
@@ -54,7 +54,9 @@ Please note that the covid-poops project is released with a [Contributor Code of
 
 ## Contributors  
 
-[&#x0040;ashleyasmus](https://github.com/ashleyasmus), and [&#x0040;eroten](https://github.com/eroten).
+Special thanks to our community contributors!  
+
+[&#x0040;ashleyasmus](https://github.com/ashleyasmus), [&#x0040;ehesch](https://github.com/ehesch), [&#x0040;eroten](https://github.com/eroten), [&#x0040;JonathanEhrlichMC](https://github.com/JonathanEhrlichMC), [&#x0040;jpflanigan](https://github.com/jpflanigan), [&#x0040;knumat](https://github.com/knumat), and [&#x0040;lfletch0025](https://github.com/lfletch0025).
 
 -----
 <a href="https://metrocouncil.org" target="_blank"><img src="metc-wastewater-covid-monitor/www/main-logo.png" style="margin-left: 50%;margin-right: 50%;"><div></div></a>

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ processing. `0_run_all.R` runs all scripts and saves final data.
 
 <PRE class="fansi fansi-output"><CODE>#&gt; <span style='color: #0000BB; font-weight: bold;'>R</span>
 #&gt; ├── <span style='color: #00BB00;'>0_run_all.R</span>
+#&gt; ├── <span style='color: #00BB00;'>d_copies_by_variant.R</span>
 #&gt; ├── <span style='color: #00BB00;'>d_covid_cases.R</span>
 #&gt; ├── <span style='color: #00BB00;'>d_load.R</span>
 #&gt; ├── <span style='color: #00BB00;'>d_variants.R</span>
 #&gt; ├── <span style='color: #00BB00;'>fig_cases_vs_load.R</span>
+#&gt; ├── <span style='color: #00BB00;'>fig_copies_by_variant.R</span>
 #&gt; ├── <span style='color: #00BB00;'>fig_sewershed.R</span>
 #&gt; └── <span style='color: #00BB00;'>fig_variants.R</span>
 </CODE></PRE>
@@ -59,8 +61,15 @@ By contributing to this project, you agree to abide by its terms.
 
 ## Contributors
 
-[@ashleyasmus](https://github.com/ashleyasmus), and
-[@eroten](https://github.com/eroten).
+Special thanks to our community contributors!
+
+[@ashleyasmus](https://github.com/ashleyasmus),
+[@ehesch](https://github.com/ehesch),
+[@eroten](https://github.com/eroten),
+[@JonathanEhrlichMC](https://github.com/JonathanEhrlichMC),
+[@jpflanigan](https://github.com/jpflanigan),
+[@knumat](https://github.com/knumat), and
+[@lfletch0025](https://github.com/lfletch0025).
 
 ------------------------------------------------------------------------
 

--- a/metc-wastewater-covid-monitor/server.R
+++ b/metc-wastewater-covid-monitor/server.R
@@ -2,8 +2,8 @@
 
 # Server -----
 server <- function(input, output) {
-
-
+  
+  
   # plots-----
   # code here to select whether variantPlot = variantFreqPlot or variantLoadPlot
   output$variantPlot <- renderPlotly({
@@ -13,7 +13,7 @@ server <- function(input, output) {
       variantLoadPlot
     }
   })
-
+  
   ## variant frequency -----
   variantFreqPlot <-
     # browser()
@@ -104,9 +104,9 @@ server <- function(input, output) {
       )
     ) %>%
     config(displayModeBar = FALSE)
-
-
-
+  
+  
+  
   ## MAIN load -----
   output$loadPlot <- renderPlotly({
     ay <- list(
@@ -120,9 +120,10 @@ server <- function(input, output) {
       ),
       zerolinewidth = 1,
       zerolinecolor = colors$suppWhite,
-      gridcolor = colors$suppWhite
+      gridcolor = colors$suppWhite,
+      rangemode = "nonnegative"
     )
-
+    
     load_plot <-
       load_data %>%
       # left_join(case_data, by = "date") %>%
@@ -195,8 +196,7 @@ server <- function(input, output) {
           xref = "paper", yref = "paper",
           xanchor = "right", yanchor = "auto",
           xshift = 0, yshift = -25
-        )
-        ,
+        ),
         showlegend = FALSE,
         margin = list(l = 75, r = 75, b = 75, pad = 10),
         hovermode = "closest",
@@ -240,7 +240,8 @@ server <- function(input, output) {
             color = councilR::colors$suppBlack
           ),
           gridcolor = colors$suppWhite,
-          zerolinecolor = colors$suppWhite
+          zerolinecolor = colors$suppWhite,
+          rangemode = "nonnegative"
         ),
         legend = list(
           orientation = "h",
@@ -252,10 +253,10 @@ server <- function(input, output) {
         )
       ) %>%
       config(displayModeBar = F)
-
+    
     load_plot
   })
-
+  
   ## variant load -----
   variantLoadPlot <-
     # browser()
@@ -342,7 +343,8 @@ server <- function(input, output) {
             size = 14,
             family = font_family_list,
             color = councilR::colors$suppBlack
-          )
+          ),
+          rangemode = "nonnegative"
         ),
         tickfont = list(
           size = 12,
@@ -363,9 +365,9 @@ server <- function(input, output) {
       )
     ) %>%
     config(displayModeBar = FALSE)
-
-
-
+  
+  
+  
   ## case and load -----
   output$casesVload <- renderPlotly({
     cases_vs_load_plot <-
@@ -383,8 +385,8 @@ server <- function(input, output) {
         color = colors$esBlue,
         fill = colors$esBlue
       )
-
-
+    
+    
     ggplotly(cases_vs_load_plot) %>%
       layout(
         annotations = ann_list,
@@ -424,7 +426,8 @@ server <- function(input, output) {
               size = 14,
               family = font_family_list,
               color = councilR::colors$suppBlack
-            )
+            ),
+            rangemode = "nonnegative"
           ),
           # tickformat = "%",
           zerolinewidth = 2,
@@ -434,7 +437,8 @@ server <- function(input, output) {
             color = councilR::colors$suppBlack
           ),
           gridcolor = "gray90",
-          zerolinecolor = "gray50"
+          zerolinecolor = "gray50",
+          rangemode = "nonnegative"
         ),
         legend = list(
           font = list(
@@ -446,20 +450,20 @@ server <- function(input, output) {
       ) %>%
       config(displayModeBar = F)
   })
-
+  
   # tables -----
   ## Prevalence table -----
   output$loadData <- renderDT(server = FALSE, {
     load_data %>%
       left_join(case_data,
-        by = c(
-          "date",
-          "covid_cases_total",
-          "covid_cases_new",
-          "covid_cases_per100K",
-          "covid_cases_7day",
-          "hover_text_case"
-        )
+                by = c(
+                  "date",
+                  "covid_cases_total",
+                  "covid_cases_new",
+                  "covid_cases_per100K",
+                  "covid_cases_7day",
+                  "hover_text_case"
+                )
       ) %>%
       select(
         -hover_text_case, -hover_text_load,
@@ -490,8 +494,8 @@ server <- function(input, output) {
       # round case rates to nearest digit:
       DT::formatRound(5:8, 0)
   })
-
-
+  
+  
   ## variant table -----
   output$variantData <- renderDT(server = FALSE, {
     variant_data %>%
@@ -519,8 +523,8 @@ server <- function(input, output) {
       DT::formatRound("frequency", 2) %>%
       DT::formatRound("frequency_7day", 2)
   })
-
-
+  
+  
   ## case table -----
   output$caseData <- renderDT(server = FALSE, {
     case_data %>%


### PR DESCRIPTION
Plotly is currently auto-generating a y-axis minimum of -70 in the main plot. This PR adds `rangemode = "nonnegative"` to each y-axis `layout()`.

In addition, I made a few comments in the figure generating scripts, re-knit the README,  and updated our contributor section with `usethis::use_tidy_thanks()`. 

Thanks to @knumat for spotting this bug!

 Closes #53 